### PR TITLE
Fix for back arrow in month selector being greyed out when it shouldn't be

### DIFF
--- a/src/scheduler/Calendar/YearMonth.js
+++ b/src/scheduler/Calendar/YearMonth.js
@@ -7,7 +7,7 @@ const prevNav = (date, firstAvailableDate) => {
     .subtract(1, "month")
     .format("YYYY-MM-DD");
 
-  if (dayjs(prevMonth).isBefore(firstAvailableDate)) {
+  if (dayjs(prevMonth).isBefore(firstAvailableDate, "month")) {
     return ["Calendar-nav--button--unavailable"];
   }
 


### PR DESCRIPTION
Fixes #9 
I changed isBefore to only look at the month granularity. Before, since it was comparing to exactly a month previous of the current day, it would always fail in this specific case if the date of the previous month (aka today) is the first available, since it's the same, not before.