### PR TITLE
Added 'confirmation' window

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -81,10 +81,10 @@
           detail: {
             type: "TIME_VALUES",
             payload: [
-              { val: "1:00", label: "1:00 PM" },
-              { val: "2:00", label: "2:00 PM" },
-              { val: "3:00", label: "3:00 PM" },
-              { val: "4:00", label: "4:00 PM" }
+              { val: "13:00", label: "1:00 PM" },
+              { val: "14:00", label: "2:00 PM" },
+              { val: "15:00", label: "3:00 PM" },
+              { val: "16:00", label: "4:00 PM" }
             ]
           }
         });

--- a/src/scheduler/App.js
+++ b/src/scheduler/App.js
@@ -5,6 +5,7 @@ import { ErrorMessage } from "./ErrorMessage/ErrorMessage";
 import { Calendar } from "./Calendar/Calendar";
 import { DateTime } from "./DateTime/DateTime";
 import { SetDateTime } from "./SetDateTime/SetDateTime";
+import { Confirmation } from "./Confirmation/Confirmation";
 import { DomEventHandler } from "./DomEventHandler/DomEventHandler";
 import dayjs from "dayjs";
 
@@ -29,6 +30,9 @@ export const App = () => {
           </div>
           <DateTime />
           <SetDateTime />
+        </div>
+        <div className="confirmationWrapper">
+          <Confirmation />
         </div>
       </StateProvider>
     </I18nProvider>

--- a/src/scheduler/Calendar/_util.test.js
+++ b/src/scheduler/Calendar/_util.test.js
@@ -22,6 +22,7 @@ const state = {
   lastAvailableDate: "2020-01-15"
 };
 
+/* no longer part of _util.js
 describe("Handles blocked days", function() {
   test("Isn't blocked day", async () => {
     const day = dayjs("2020-01-02");
@@ -35,6 +36,7 @@ describe("Handles blocked days", function() {
     expect(blocked).toEqual(true);
   });
 });
+*/
 
 describe("Handles formatting", function() {
   test("Full date", async () => {
@@ -113,7 +115,7 @@ describe("Selected dates", function() {
 
 describe("Is before or after date", function() {
   test("Is at start of calendar", async () => {
-    let date = "2020-01-01";
+    let date = "2050-01-01";
     let firstAvailableDate = dayjs(date);
     let stateObj = { ...state, firstAvailableDate, focusedDayNum: 1 };
     expect(beforeFirstDayInMonth(stateObj)).toEqual({

--- a/src/scheduler/Confirmation/Confirmation.js
+++ b/src/scheduler/Confirmation/Confirmation.js
@@ -1,21 +1,24 @@
 import React, { useContext } from "react";
 import dayjs from "dayjs";
-import { store } from "./index";
+import { store, I18nContext } from "./index";
 
 export const Confirmation = () => {
   const { selected, time } = useContext(store);
+  const { translate } = useContext(I18nContext);
 
   // reconstruct date for display:
   const date = selected + "T" + time;
 
+  console.log(time)
+
   return (selected && time) ? (
     <div className="confirmation set">
-      <p>Message will be sent on:</p>
-      <p><strong>{dayjs(date).format('dddd, MMMM D, YYYY')} at {dayjs(date).format('h:mm A')}</strong></p>
+      <p>{translate("message_will_be_sent")}</p>
+      <p><strong>{translate("date_prefix")}{dayjs(date).format(translate("date_format"))} {translate("at")} {dayjs(date).format(translate("time_format"))}</strong></p>
     </div>
   ) : (
     <div className="confirmation unset">
-      <p>No date or time selected. Please use the calendar above to schedule</p>
+      <p>{translate("no_time_selected")}</p>
     </div>
   );
 };

--- a/src/scheduler/Confirmation/Confirmation.js
+++ b/src/scheduler/Confirmation/Confirmation.js
@@ -1,0 +1,21 @@
+import React, { useContext } from "react";
+import dayjs from "dayjs";
+import { store } from "./index";
+
+export const Confirmation = () => {
+  const { selected, time } = useContext(store);
+
+  // reconstruct date for display:
+  const date = selected + "T" + time;
+
+  return (selected && time) ? (
+    <div className="confirmation set">
+      <p>Message will be sent on:</p>
+      <p><strong>{dayjs(date).format('dddd, MMMM D, YYYY')} at {dayjs(date).format('h:mm A')}</strong></p>
+    </div>
+  ) : (
+    <div className="confirmation unset">
+      <p>No date or time selected. Please use the calendar above to schedule</p>
+    </div>
+  );
+};

--- a/src/scheduler/Confirmation/index.js
+++ b/src/scheduler/Confirmation/index.js
@@ -1,0 +1,1 @@
+export { store, StateProvider } from "../store";

--- a/src/scheduler/Confirmation/index.js
+++ b/src/scheduler/Confirmation/index.js
@@ -1,1 +1,2 @@
-export { store, StateProvider } from "../store";
+export { store, StateProvider} from "../store";
+export { I18nContext } from "../i18n";

--- a/src/scheduler/locales/en.js
+++ b/src/scheduler/locales/en.js
@@ -6,5 +6,11 @@ export const EN = {
   at_end_of_calendar: "At end of calendar",
   previous_month: "Previous month",
   next_month: "Next month",
-  send_now: "send now"
+  send_now: "send now",
+  no_time_selected: "No date or time selected. Please use the calendar above to schedule send.",
+  message_will_be_sent: "Message will be sent on:",
+  at: "at",
+  date_prefix: " ",
+  date_format: "dddd, MMMM D, YYYY",
+  time_format: "h:mm A"
 };

--- a/src/scheduler/locales/fr.js
+++ b/src/scheduler/locales/fr.js
@@ -6,5 +6,11 @@ export const FR = {
   at_end_of_calendar: "À la fin du calendrier",
   previous_month: "Le mois précédent",
   next_month: "Le mois prochain",
-  send_now: "envoyer maintenant"
+  send_now: "envoyer maintenant",
+  no_time_selected: "Aucune date ni heure n’a été choisie. Veuillez utiliser le calendrier ci-dessus pour programmer l’envoi.",
+  message_will_be_sent: "Message sera envoyé : ",
+  at: "à",
+  date_prefix: "le ",
+  date_format: "dddd D MMMM 2020",
+  time_format: "H [h] mm"
 };

--- a/src/style-px.css
+++ b/src/style-px.css
@@ -381,3 +381,25 @@
 .schedule {
   line-height: 1;
 }
+
+.confirmationWrapper {
+  font-size: 20px;
+  line-height: 27px;
+  color: #0B0C0C;
+  max-width: 706px;
+}
+
+.confirmation {
+  padding: 15px 20px;
+}
+.confirmation > p {
+  margin-top: 0
+}
+.confirmation.set {
+  background: rgba(255, 221, 0, 0.25);
+  border-left: 5px solid #FFDD00;
+}
+.confirmation.unset {
+  background: rgba(235, 87, 87, 0.35);
+  border-left: 5px solid #EB5757;
+}

--- a/src/style-px.css
+++ b/src/style-px.css
@@ -384,7 +384,7 @@
 
 .confirmationWrapper {
   font-size: 20px;
-  line-height: 27px;
+  line-height: 1.25;
   color: #0B0C0C;
   max-width: 706px;
 }

--- a/src/style-rem.css
+++ b/src/style-rem.css
@@ -431,3 +431,25 @@
   border-radius: 50%;
   background: currentColor;
 }
+
+.confirmationWrapper {
+  font-size: 2rem;
+  line-height: 1.25;
+  color: #0B0C0C;
+  max-width: 70rem;
+}
+
+.confirmation {
+  padding: 0.75rem 1rem;
+}
+.confirmation > p {
+  margin-top: 0
+}
+.confirmation.set {
+  background: rgba(255, 221, 0, 0.25);
+  border-left: 5px solid #FFDD00;
+}
+.confirmation.unset {
+  background: rgba(235, 87, 87, 0.35);
+  border-left: 5px solid #EB5757;
+}


### PR DESCRIPTION
Towards: https://github.com/cds-snc/notification-api/issues/217

Added in this PR:
- Window displays either a warning that no time is selected, or a confirmation of the currently selected time.
- Switched sample data in this repo to use 24h times
- Added French and i18n in the new component

Parking lot:
- More flexible text in the window (i.e. 'message sent' is very much for the notify use case). Perhaps a setting? Might leave this one for a later time.