### PR TITLE
Update logic for times shown as valid for 'today'.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -32,11 +32,11 @@
       };
 
       const isBlockedDay = day => {
-        const today = new Date()
+        const today = new Date().setHours(0,0,0,0)
         if (today > day) {
           return true;
         }
-        const blockedDays = [1, 3, 4]
+        const blockedDays = [1,4] //1,3,4
         if (blockedDays && blockedDays.indexOf(day.$W) > -1) {
           return true;
         }
@@ -83,6 +83,7 @@
           detail: {
             type: "TIME_VALUES",
             payload: [
+              { val: "9:00", label: "9:00 AM" },
               { val: "13:00", label: "1:00 PM" },
               { val: "14:00", label: "2:00 PM" },
               { val: "15:00", label: "3:00 PM" },

--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { App } from "./scheduler/App";
 
-/*
-window.schedulerOptions.populateTimes = () => {
-  console.log("new populateTimes");
-  return [
-    { val: "1:00", label: "1:00 PM" },
-    { val: "2:00", label: "2:00 PM" },
-    { val: "3:00", label: "3:00 PM" },
-    { val: "4:00", label: "4:00 PM" }
-  ];
-};
-
-const myEvent = new CustomEvent("build", { detail: "hello" });
-window.dispatchEvent(myEvent);
-*/
-
 // schedule-send-at
 window.renderCalendar = target => {
   ReactDOM.render(<App />, document.getElementById(target));

--- a/src/scheduler/Calendar/_util.test.js
+++ b/src/scheduler/Calendar/_util.test.js
@@ -1,5 +1,4 @@
 import {
-  isBlockedDay,
   formattedDay,
   yearMonthDay,
   parseDay,
@@ -12,7 +11,6 @@ import {
   setSelected,
   beforeFirstDayInMonth,
   afterLastDayInMonth,
-  getNextDay
 } from "./_util";
 import dayjs from "dayjs";
 
@@ -21,22 +19,6 @@ const state = {
   firstAvailableDate: "2020-01-01",
   lastAvailableDate: "2020-01-15"
 };
-
-/* no longer part of _util.js
-describe("Handles blocked days", function() {
-  test("Isn't blocked day", async () => {
-    const day = dayjs("2020-01-02");
-    const blocked = isBlockedDay(day, state);
-    expect(blocked).toEqual(false);
-  });
-
-  test("Is blocked day", async () => {
-    const day = dayjs("2020-02-02");
-    const blocked = isBlockedDay(day, state);
-    expect(blocked).toEqual(true);
-  });
-});
-*/
 
 describe("Handles formatting", function() {
   test("Full date", async () => {

--- a/src/scheduler/Confirmation/Confirmation.js
+++ b/src/scheduler/Confirmation/Confirmation.js
@@ -9,8 +9,6 @@ export const Confirmation = () => {
   // reconstruct date for display:
   const date = selected + "T" + time;
 
-  console.log(time)
-
   return (selected && time) ? (
     <div className="confirmation set">
       <p>{translate("message_will_be_sent")}</p>

--- a/src/scheduler/Time/Time.js
+++ b/src/scheduler/Time/Time.js
@@ -1,8 +1,11 @@
 import React, { useContext } from "react";
-import { store } from "./index";
+import { store, timeValuesToday, dateIsToday } from "./index";
 
 export const Time = ({ name }) => {
-  const { time, time_values, dispatch } = useContext(store);
+  const { time, time_values, dispatch, selected } = useContext(store);
+
+  // if today, check valid time values
+  const valid_time_values = dateIsToday(selected) ? timeValuesToday(selected, time_values) : time_values;
   
   return (
     <div className="Nav--select">
@@ -18,7 +21,7 @@ export const Time = ({ name }) => {
         aria-label={name}
         value={time}
       >
-        {time_values.map(item => {
+        {valid_time_values.map(item => {
           return (
             <option key={item.label} value={item.val}>
               {item.label}

--- a/src/scheduler/Time/_util.js
+++ b/src/scheduler/Time/_util.js
@@ -44,11 +44,13 @@ export const dateIsToday = (date) => {
     .set("minute", 0)
     .set("second", 0)
     .set("millisecond", 0);
+
   return today.isSame(dayjs(date[0]), 'day');
 };
 
 export const timeValuesToday = (selected, time_values) => {
   const today = dayjs()
+  
   return time_values.filter(time => {
     const t = dayjs(selected + "T" + time.val);
     return t.isAfter(today)
@@ -57,6 +59,7 @@ export const timeValuesToday = (selected, time_values) => {
 
 export const getStartTime = date => {
   let startTime = 0;
+
   if (dateIsToday(date)) {
     const d = new Date();
     startTime = Number(d.getHours() + 1) * 60;

--- a/src/scheduler/Time/_util.js
+++ b/src/scheduler/Time/_util.js
@@ -38,19 +38,26 @@ export const populateTimes = (_24hr = false, date) => {
   return times;
 };
 
-export const dateIsToday = (today, date) => {
-  return dayjs(today).isSame(dayjs(date));
-};
-
-export const getStartTime = date => {
+export const dateIsToday = (date) => {
   const today = dayjs()
     .set("hour", 0)
     .set("minute", 0)
     .set("second", 0)
     .set("millisecond", 0);
+  return today.isSame(dayjs(date[0]), 'day');
+};
 
+export const timeValuesToday = (selected, time_values) => {
+  const today = dayjs()
+  return time_values.filter(time => {
+    const t = dayjs(selected + "T" + time.val);
+    return t.isAfter(today)
+  })
+}
+
+export const getStartTime = date => {
   let startTime = 0;
-  if (dateIsToday(today, date)) {
+  if (dateIsToday(date)) {
     const d = new Date();
     startTime = Number(d.getHours() + 1) * 60;
   }

--- a/src/scheduler/Time/_util.test.js
+++ b/src/scheduler/Time/_util.test.js
@@ -1,0 +1,57 @@
+import {
+  populateTimes,
+  dateIsToday,
+  timeValuesToday,
+  getStartTime,
+} from "./_util";
+import dayjs from "dayjs";
+
+const state = {
+  today: "2020-01-01",
+  selected: ["2020-01-01"],
+  time_values: [
+    { val: "1:00", label: "1:00 AM" },
+    { val: "9:00", label: "9:00 AM" },
+    { val: "13:00", label: "1:00 PM" },
+    { val: "14:00", label: "2:00 PM" },
+    { val: "15:00", label: "3:00 PM" },
+    { val: "16:00", label: "4:00 PM" }
+  ]
+};
+
+describe("Time utils", function() {
+  const dayjsToday = dayjs()
+    .set("hour", 0)
+    .set("minute", 0)
+    .set("second", 0)
+    .set("millisecond", 0);
+
+  const constructedToday = dayjsToday.year() + "-" + (dayjsToday.month() + 1) + "-" + dayjsToday.date()
+
+  test("getStartTime correctly returns midnight for a day that is not today", async () => {
+    expect(getStartTime(state.today)).toBe(0); // midnight
+  });
+
+  test("getStartTime does not return midnight when the day is today", async () => {
+    expect(getStartTime(dayjsToday)).not.toBe(0);
+  });
+
+  test("Populate Times shows all 24h for a future date", async () => {
+    expect(populateTimes(false, ["2050-01-01"])).toHaveLength(24)
+  });
+
+  test("dateIsToday returns true when evaluating today", async () => {
+    expect(dateIsToday([dayjsToday])).toBeTruthy;
+  });
+
+  test("dateIsToday returns false when evaluating a different day", async () => {
+    expect(dateIsToday(state.selected)).toBeFalsy;
+  });
+
+  test("timeValuesToday culls times that have already passed", async () => {
+    // this test will fail between midnight and 1 AM
+    const culled_time_values = timeValuesToday(constructedToday, state.time_values);
+    expect(culled_time_values).not.toHaveLength(6);
+  })
+
+})

--- a/src/scheduler/store.js
+++ b/src/scheduler/store.js
@@ -63,8 +63,6 @@ export const defaultState = (
   };
 };
 
-//
-
 let options = {};
 
 options = { setIntialState: defaultState, ...window.schedulerOptions };
@@ -99,6 +97,7 @@ export const StateProvider = ({ value, children }) => {
         newState = { ...state, time: action.payload };
         break;
       case "TIME_VALUES":
+        //time_values = populateTimes(action.payload)
         newState = { ...state, time_values: action.payload };
         break;
       case "SELECT_DATE":


### PR DESCRIPTION
- Don't display times that are in the past
- Make 'today' more clear in parts of the code (i.e. comparisons made for today are now at the right granularity, today is midnight when checking for blocked days)
- remove some old comments
- added tests for utils in Time component