### PR TITLE
Fix for a couple downstream bugs in notification

### DIFF
--- a/src/scheduler/Time/_util.js
+++ b/src/scheduler/Time/_util.js
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 
-export const populateTimes = (_24hr = false, date) => {
-  const startTime = getStartTime(date);
+export const populateTimes = (_24hr = false) => {
+  const startTime = 0
   let times = [];
   let hours, hours24, minutes, ampm;
 
@@ -56,14 +56,3 @@ export const timeValuesToday = (selected, time_values) => {
     return t.isAfter(today)
   })
 }
-
-export const getStartTime = date => {
-  let startTime = 0;
-
-  if (dateIsToday(date)) {
-    const d = new Date();
-    startTime = Number(d.getHours() + 1) * 60;
-  }
-
-  return startTime;
-};

--- a/src/scheduler/Time/_util.test.js
+++ b/src/scheduler/Time/_util.test.js
@@ -2,7 +2,6 @@ import {
   populateTimes,
   dateIsToday,
   timeValuesToday,
-  getStartTime,
 } from "./_util";
 import dayjs from "dayjs";
 
@@ -28,16 +27,8 @@ describe("Time utils", function() {
 
   const constructedToday = dayjsToday.year() + "-" + (dayjsToday.month() + 1) + "-" + dayjsToday.date()
 
-  test("getStartTime correctly returns midnight for a day that is not today", async () => {
-    expect(getStartTime(state.today)).toBe(0); // midnight
-  });
-
-  test("getStartTime does not return midnight when the day is today", async () => {
-    expect(getStartTime(dayjsToday)).not.toBe(0);
-  });
-
   test("Populate Times shows all 24h for a future date", async () => {
-    expect(populateTimes(false, ["2050-01-01"])).toHaveLength(24)
+    expect(populateTimes(false)).toHaveLength(24)
   });
 
   test("dateIsToday returns true when evaluating today", async () => {

--- a/src/scheduler/store.js
+++ b/src/scheduler/store.js
@@ -33,7 +33,7 @@ export const defaultState = (
     firstDay: defautFirstDay
   }
 ) => {
-  const { today, firstDay } = data;
+  const { today, firstDay } = data.defaultState ? data.defaultState: data;
 
   let lastAvailableDate;
   lastAvailableDate = dayjs(firstDay).add(1, "month");
@@ -45,7 +45,7 @@ export const defaultState = (
     );
   };
 
-  const time_values = populateTimes(false, defautFirstDay);
+  const time_values = populateTimes(false);
 
   return {
     today,


### PR DESCRIPTION
- getStartTime isn't actually needed anymore because of the new culling in the Time component, and was causing all dates in Notify to only show times after today's start time (i.e. if it's noon, all days were showing 1pm as the first time)
- defaultState is called with two different object formats at different times. I'm going to make an issue to refactor this properly, but for now I just made the function able to deal with both objects it might get as an input