### PR TITLE
Red warning box fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,9 +25,11 @@
     <script>
       const populateTimes = () => {
         return [
-          { val: "1:00", label: "1:00 AM" },
-          { val: "2:00", label: "2:00 AM" },
-          { val: "3:00", label: "3:00 AM" }
+          { val: "9:00", label: "9:00 AM" },
+          { val: "13:00", label: "1:00 PM" },
+          { val: "14:00", label: "2:00 PM" },
+          { val: "15:00", label: "3:00 PM" },
+          { val: "16:00", label: "4:00 PM" }
         ];
       };
 
@@ -60,12 +62,12 @@
             lastAvailableDate: lastAvailableDate,
             date: dayjs(firstDay).format("YYYY-MM-DD"),
             time: time_values[0].val,
-            time_values: time_values,
+            //time_values: time_values,
             isBlockedDay: isBlockedDay,
             selected: [dayjs(firstDay).format("YYYY-MM-DD")],
             focusedDayNum: dayjs(firstDay).format("D"),
             updateMessage: "",
-            _24hr: "en",
+            _24hr: "on",
             errors: "",
             hiddenValueRef: document.getElementById("hidden-value")
           };
@@ -77,22 +79,6 @@
       setTimeout(function() {
         window.renderCalendar("schedule-send-at");
       }, 2000);
-
-      setTimeout(function() {
-        const myEvent = new CustomEvent("build", {
-          detail: {
-            type: "TIME_VALUES",
-            payload: [
-              { val: "9:00", label: "9:00 AM" },
-              { val: "13:00", label: "1:00 PM" },
-              { val: "14:00", label: "2:00 PM" },
-              { val: "15:00", label: "3:00 PM" },
-              { val: "16:00", label: "4:00 PM" }
-            ]
-          }
-        });
-        window.dispatchEvent(myEvent);
-      }, 10000);
     </script>
   </body>
 </html>

--- a/src/scheduler/Confirmation/Confirmation.js
+++ b/src/scheduler/Confirmation/Confirmation.js
@@ -9,7 +9,7 @@ export const Confirmation = () => {
   // reconstruct date for display:
   const date = selected + "T" + time;
 
-  return (selected && time) ? (
+  return (selected.length > 0 && time) ? (
     <div className="confirmation set">
       <p>{translate("message_will_be_sent")}</p>
       <p><strong>{translate("date_prefix")}{dayjs(date).format(translate("date_format"))} {translate("at")} {dayjs(date).format(translate("time_format"))}</strong></p>

--- a/src/scheduler/DomEventHandler/DomEventHandler.js
+++ b/src/scheduler/DomEventHandler/DomEventHandler.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext } from "react";
 import { store } from "./index";
 
 const useBuildEvent = () => {

--- a/src/scheduler/Toggle/Toggle.js
+++ b/src/scheduler/Toggle/Toggle.js
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { store } from "./index";
 
 export const Toggle = () => {
-  const { _24hr, time, dispatch, selected } = useContext(store);
+  const { _24hr, time, dispatch } = useContext(store);
 
   if (time === "") {
     return <div className="choice choice--radios"></div>;

--- a/src/scheduler/store.js
+++ b/src/scheduler/store.js
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer } from "react";
-import { populateTimes } from "./Time/_util";
+import { populateTimes, dateIsToday, timeValuesToday } from "./Time/_util";
 import dayjs from "dayjs";
 import "dayjs/locale/fr-ca";
 import {
@@ -39,8 +39,10 @@ export const defaultState = (
   lastAvailableDate = dayjs(firstDay).add(1, "month");
 
   const blockedDay = day => {
+    const beforeFirstDay = firstDay ? dayjs(day).isBefore(firstDay) : false;
     return (
-      dayjs(day).isBefore(firstDay) ||
+      today > day ||
+      beforeFirstDay ||
       dayjs(day).isAfter(lastAvailableDate)
     );
   };
@@ -104,16 +106,18 @@ export const StateProvider = ({ value, children }) => {
         if (state.isBlockedDay(dayjs(action.payload))) {
           newState = { ...state };
         } else {
+          let newTime = dateIsToday([action.payload]) ? timeValuesToday([action.payload], state.time_values)[0].val : state.time;
           newState = {
             ...state,
             selected: setSelected(state.selected, action.payload),
-            focusedDayNum: parseDay(action.payload)
+            focusedDayNum: parseDay(action.payload),
+            time: newTime
           };
 
           newState.errors = "";
-
+          /*
           if (
-            JSON.stringify(newState.selected) === JSON.stringify(state.selected)
+            newState.selected.length === 0
           ) {
             // show deselect error
             newState.errors = [
@@ -123,7 +127,7 @@ export const StateProvider = ({ value, children }) => {
                 target: "Calendar-dates"
               }
             ];
-          }
+          }*/
         }
         break;
       case "SELECT_NEXT":


### PR DESCRIPTION
- Show red box when no date is set (instead of yellow confirmation box with 'Invalid Date')
- Remove the old deselect warning (which wasn't showing anyways - also fixed this but it's commented out so we don't have 2 red boxes when no date is selected)
- On pageload start with 24h radio box selected
- Make sure a correct time is displayed when date is swapped to a date that doesn't have that time available
- Remove the initial populateTimes and 10s timeout that sets them
- Remove some unused vars flagged by LGTM on notify port