### PR TITLE
Fixed JS crash between 11pm and 11:59pm when no time values are available

### DIFF
--- a/src/scheduler/Calendar/Calendar.test.js
+++ b/src/scheduler/Calendar/Calendar.test.js
@@ -18,7 +18,7 @@ describe("Calendar", function() {
   const providerState = setIntialState({ today, firstDay });
 
   // tests
-  test("Renders a calendar", async () => {
+test("Renders a calendar", async () => {
     const { getByLabelText, container, debug } = render(
       <I18nProvider value={i18nState}>
         <StateProvider value={providerState}>
@@ -52,7 +52,35 @@ describe("Calendar", function() {
     expect(label).toEqual("Unavailable, Friday February 28 2020");
   });
 
-  test("Handles key nav events", async () => {
+test("Renders a calendar on on a day with not time slot available, i.e. past 11 pm", async () => {
+    const today = dayjs("2020-02-29").hour(23).minute(1);
+    const firstDay = dayjs("2020-03-01");
+    const lateDayState = setIntialState({ today, firstDay });
+    const { getByLabelText, container, debug } = render(
+      <I18nProvider value={i18nState}>
+        <StateProvider value={lateDayState}>
+          <Calendar />
+        </StateProvider>
+      </I18nProvider>
+    );
+
+    // shows month name for the date provided
+    expect(container.querySelector(`.Nav--month`)).toHaveTextContent(
+      "March"
+    );
+
+    // renders a day
+    expect(container.querySelector(`[data-day="1"]`)).toHaveTextContent("1");
+
+    // marks day after available time period as unavailable
+    const label = container
+      .querySelector(`[data-day="6"]`)
+      .getAttribute("aria-label");
+
+    expect(label).toEqual("Unavailable, Friday March 06 2020");
+  });
+
+test("Handles key nav events", async () => {
     const { container, getByLabelText } = render(
       <I18nProvider value={i18nState}>
         <StateProvider value={providerState}>

--- a/src/scheduler/Calendar/Calendar.test.js
+++ b/src/scheduler/Calendar/Calendar.test.js
@@ -52,7 +52,7 @@ test("Renders a calendar", async () => {
     expect(label).toEqual("Unavailable, Friday February 28 2020");
   });
 
-test("Renders a calendar on on a day with not time slot available, i.e. past 11 pm", async () => {
+test("Renders a calendar on on a day with no time slot available anymore past 11 pm", async () => {
     const today = dayjs("2020-02-29").hour(23).minute(1);
     const firstDay = dayjs("2020-03-01");
     const lateDayState = setIntialState({ today, firstDay });

--- a/src/scheduler/Calendar/_util.js
+++ b/src/scheduler/Calendar/_util.js
@@ -122,7 +122,7 @@ export const beforeFirstDayInMonth = state => {
 export const afterLastDayInMonth = state => {
   if (Number(state.focusedDayNum) === Number(state.lastDay)) {
     const newMonth = dayjs(state.date)
-      .add(1, "month")
+      .add(1, "day")
       .format("YYYY-MM-DD");
 
     if (dayjs(newMonth).isAfter(yearMonthDay(state.lastAvailableDate))) {

--- a/src/scheduler/Calendar/_util.test.js
+++ b/src/scheduler/Calendar/_util.test.js
@@ -129,7 +129,7 @@ describe("Is before or after date", function() {
   });
 
   test("Is at start of month but before last available", async () => {
-    let date = "2020-02-01";
+    let date = "2020-02-29";
     let lastDay = getLastDay(date);
     let lastAvailableDate = dayjs("2020-03-31");
     let stateObj = {

--- a/src/scheduler/Time/Time.js
+++ b/src/scheduler/Time/Time.js
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import React, { useContext } from "react";
 import { store, timeValuesToday, dateIsToday } from "./index";
 
@@ -5,7 +6,7 @@ export const Time = ({ name }) => {
   const { time, time_values, dispatch, selected } = useContext(store);
 
   // if today, check valid time values
-  const valid_time_values = dateIsToday(selected) ? timeValuesToday(selected, time_values) : time_values;
+  const valid_time_values = dateIsToday(selected) ? timeValuesToday(dayjs(), selected, time_values) : time_values;
   
   return (
     <div className="Nav--select">

--- a/src/scheduler/Time/_util.js
+++ b/src/scheduler/Time/_util.js
@@ -48,11 +48,9 @@ export const dateIsToday = (date) => {
   return today.isSame(dayjs(date[0]), 'day');
 };
 
-export const timeValuesToday = (selected, time_values) => {
-  const today = dayjs()
-  
+export const timeValuesToday = (now, selected, time_values) => {
   return time_values.filter(time => {
     const t = dayjs(selected + "T" + time.val);
-    return t.isAfter(today)
+    return t.isAfter(now)
   })
 }

--- a/src/scheduler/Time/_util.test.js
+++ b/src/scheduler/Time/_util.test.js
@@ -40,9 +40,9 @@ describe("Time utils", function() {
   });
 
   test("timeValuesToday culls times that have already passed", async () => {
-    // this test will fail between midnight and 1 AM
-    const culled_time_values = timeValuesToday(constructedToday, state.time_values);
-    expect(culled_time_values).not.toHaveLength(6);
+    const now = dayjs().hour(13).minute(59).toString();
+    const culled_time_values = timeValuesToday(now, constructedToday, state.time_values);
+    expect(culled_time_values).toHaveLength(3);
   })
 
 })


### PR DESCRIPTION
# Summary | Résumé

* [TRELLO](https://trello.com/c/q1wLKVzX/373-dates-and-times-show-up-as-2021-03-09t035944889496z-late-at-night): Fix the scheduler bug that triggers a Javascript error past 23h00 until 23h59 included.
* Fix month not switching on last month date and smaller availability period of less than a month.

Show case of these two bugs are demonstrated in this other draft PR/branch:
https://github.com/cds-snc/notification-scheduler/pull/33

# Test instructions | Instructions pour tester la modification

1. Set the local computer clock to 23h00.
2. Start the calendar via `npm run start`.

Previously, the scheduler would not properly load past 23h00 due to a Javascript error. This should now load fine and display all available hourly time slots for the next day.

# Help requested | Aide requise

There is one test that fails with a timeout on a calendar month change. This might be due to different Reactjs state. 

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
