### PR TITLE
Replaces class with className - fixes React warning

### DIFF
--- a/src/scheduler/App.js
+++ b/src/scheduler/App.js
@@ -25,7 +25,7 @@ export const App = () => {
       <StateProvider value={providerState}>
         <DomEventHandler />
         <ErrorMessage />
-        <p class="messageTextStyle">{translate('select_date')}</p>
+        <p className="messageTextStyle">{translate('select_date')}</p>
         <div className="schedule">
           <div>
             <Calendar />


### PR DESCRIPTION
Fixes typo on `messageTextStyle` p tag

React uses className vs class