### PR TITLE
docs: update security policy email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 # Security
 
-**Do not post any security issues on the public repository!** Security vulnerabilities must be reported by email to [john.obrien@tbs-sct.gc.ca](mailto:john.obrien@tbs-sct.gc.ca)
+**Do not post any security issues on the public repository!** Security vulnerabilities must be reported by email to [security@cds-snc.ca](mailto:security@cds-snc.ca)
 
 ______________________
 
 ## Sécurité
 
-**Ne publiez aucun problème de sécurité sur le dépôt publique!** Les vulnérabilités de sécurité doivent être signalées par courriel à [john.obrien@tbs-sct.gc.ca](mailto:john.obrien@tbs-sct.gc.ca)
+**Ne publiez aucun problème de sécurité sur le dépôt publique!** Les vulnérabilités de sécurité doivent être signalées par courriel à [security@cds-snc.ca](mailto:security@cds-snc.ca)


### PR DESCRIPTION
# Summary
Update the security policy with the generic CDS Security email address.